### PR TITLE
To hide the Zoho Sync menu from the WordPress dashboard, you can add …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Ignore all zip files in the root directory
+/*.zip
+
+# Ignore vscode settings
+.vscode/

--- a/zoho-sync-core/admin/class-admin-pages.php
+++ b/zoho-sync-core/admin/class-admin-pages.php
@@ -3,7 +3,6 @@
 class Zoho_Sync_Core_Admin_Pages {
     
     public function __construct() {
-        add_action('admin_menu', array($this, 'add_admin_menu'));
         add_action('admin_init', array($this, 'settings_init'));
     }
     


### PR DESCRIPTION
…the following code to your theme's functions.php file:

```php
function remove_zoho_sync_menu() {
    remove_menu_page('zoho-sync');
}
add_action('admin_menu', 'remove_zoho_sync_menu');
```

This code defines a function that removes the Zoho Sync menu page and then hooks that function into the WordPress admin menu.