### PR TITLE
Fix: Corregir la inicialización de los componentes de administración

### DIFF
--- a/zoho-sync-core/admin/class-admin-pages.php
+++ b/zoho-sync-core/admin/class-admin-pages.php
@@ -3,6 +3,7 @@
 class Zoho_Sync_Core_Admin_Pages {
     
     public function __construct() {
+        add_action('admin_menu', array($this, 'add_admin_menu'));
         add_action('admin_init', array($this, 'settings_init'));
     }
     

--- a/zoho-sync-core/zoho-sync-core.php
+++ b/zoho-sync-core/zoho-sync-core.php
@@ -119,6 +119,11 @@ final class ZohoSyncCore {
         
         // Verificar dependencias
         add_action('admin_init', array($this, 'check_dependencies'));
+
+        // Inicializar componentes de admin
+        if (is_admin()) {
+            add_action('admin_menu', array($this, 'init_admin_components'));
+        }
     }
     
     /**
@@ -226,11 +231,15 @@ final class ZohoSyncCore {
         // Inicializar core principal
         $this->core = new Zoho_Sync_Core_Core();
         
-        // Inicializar páginas de administración si estamos en el admin
-        if (is_admin()) {
-            new Zoho_Sync_Core_Admin_Pages();
-            new Zoho_Sync_Core_Admin_Notices();
-        }
+        // Los componentes de administración se inicializan en su propio hook
+    }
+
+    /**
+     * Inicializar componentes de administración
+     */
+    public function init_admin_components() {
+        new Zoho_Sync_Core_Admin_Pages();
+        new Zoho_Sync_Core_Admin_Notices();
     }
     
     /**


### PR DESCRIPTION
He refactorizado la forma en que se inicializan los componentes de administración para asegurar que se carguen en el hook 'admin_menu'. Esto soluciona un problema que impedía que el menú de Zoho Sync se mostrara en el dashboard de WordPress y también corrige las advertencias sobre la carga de traducciones.