### PR TITLE
Fix: Añadir los métodos que faltaban en la clase Admin_Pages

### DIFF
--- a/zoho-sync-core/admin/class-admin-pages.php
+++ b/zoho-sync-core/admin/class-admin-pages.php
@@ -28,4 +28,12 @@ class Zoho_Sync_Core_Admin_Pages {
             array($this, 'dashboard_page')
         );
     }
+
+    public function admin_page() {
+        require_once ZOHO_SYNC_CORE_ADMIN_DIR . 'partials/settings-display.php';
+    }
+
+    public function dashboard_page() {
+        require_once ZOHO_SYNC_CORE_ADMIN_DIR . 'partials/dashboard-display.php';
+    }
 }


### PR DESCRIPTION
He añadido los métodos `admin_page` y `dashboard_page` a la clase `Zoho_Sync_Core_Admin_Pages` para solucionar un error fatal que impedía que se mostraran las páginas de administración.