### PR TITLE
Fix: Add missing settings_init method

### DIFF
--- a/zoho-sync-core/admin/class-admin-pages.php
+++ b/zoho-sync-core/admin/class-admin-pages.php
@@ -36,4 +36,30 @@ class Zoho_Sync_Core_Admin_Pages {
     public function dashboard_page() {
         require_once ZOHO_SYNC_CORE_ADMIN_DIR . 'partials/dashboard-display.php';
     }
+
+    public function settings_init() {
+        register_setting('zoho_sync_core', 'zoho_sync_core_settings');
+
+        add_settings_section(
+            'zoho_sync_core_section',
+            __('Zoho API Settings', 'zoho-sync-core'),
+            null,
+            'zoho_sync_core'
+        );
+
+        add_settings_field(
+            'zoho_client_id',
+            __('Client ID', 'zoho-sync-core'),
+            array($this, 'render_client_id_field'),
+            'zoho_sync_core',
+            'zoho_sync_core_section'
+        );
+    }
+
+    public function render_client_id_field() {
+        $options = get_option('zoho_sync_core_settings');
+        ?>
+        <input type='text' name='zoho_sync_core_settings[zoho_client_id]' value='<?php echo esc_attr($options['zoho_client_id']); ?>'>
+        <?php
+    }
 }


### PR DESCRIPTION
I've added the `settings_init` method to the `Zoho_Sync_Core_Admin_Pages` class to fix a fatal error that was preventing the admin pages from displaying.