### PR TITLE
Fix: Añadir el formulario de configuración a la página de ajustes

### DIFF
--- a/zoho-sync-core/admin/partials/settings-display.php
+++ b/zoho-sync-core/admin/partials/settings-display.php
@@ -1,2 +1,10 @@
-<?php
-// Vista para la configuración
+<div class="wrap">
+    <h1><?php echo esc_html(get_admin_page_title()); ?></h1>
+    <form action="options.php" method="post">
+        <?php
+        settings_fields('zoho_sync_core');
+        do_settings_sections('zoho_sync_core');
+        submit_button(__('Save Settings', 'zoho-sync-core'));
+        ?>
+    </form>
+</div>


### PR DESCRIPTION
He añadido el código HTML y PHP necesario para mostrar el formulario de configuración en la página de ajustes del plugin. Esto soluciona un problema que provocaba que la página de configuración apareciera en blanco.