### PR TITLE
Fix: Añadir comprobación para evitar el aviso de acceso a un array en…

### DIFF
--- a/zoho-sync-core/admin/class-admin-pages.php
+++ b/zoho-sync-core/admin/class-admin-pages.php
@@ -58,8 +58,9 @@ class Zoho_Sync_Core_Admin_Pages {
 
     public function render_client_id_field() {
         $options = get_option('zoho_sync_core_settings');
+        $client_id = isset($options['zoho_client_id']) ? $options['zoho_client_id'] : '';
         ?>
-        <input type='text' name='zoho_sync_core_settings[zoho_client_id]' value='<?php echo esc_attr($options['zoho_client_id']); ?>'>
+        <input type='text' name='zoho_sync_core_settings[zoho_client_id]' value='<?php echo esc_attr($client_id); ?>'>
         <?php
     }
 }


### PR DESCRIPTION
… un valor booleano

He añadido una comprobación en el método `render_client_id_field` para evitar que se intente acceder a un índice de un array en un valor booleano. Esto soluciona un aviso que aparecía cuando la opción de configuración aún no se había guardado.