### PR TITLE
Fix: Añadir manejador de errores a la llamada AJAX

### DIFF
--- a/zoho-sync-core/admin/assets/js/admin.js
+++ b/zoho-sync-core/admin/assets/js/admin.js
@@ -17,6 +17,9 @@
                 } else {
                     $status.text('Connection failed: ' + response.data.message);
                 }
+            }).fail(function(xhr, status, error) {
+                $status.text('An error occurred: ' + error);
+                console.error(xhr.responseText);
             });
         });
     });


### PR DESCRIPTION
He añadido un manejador de errores a la llamada AJAX en el script de administración para que se muestren los errores que ocurran durante la petición. Esto te ayudará a diagnosticar por qué la comprobación de la conexión se queda en 'Checking...'.