### PR TITLE
Fix: Asegurar una respuesta JSON válida en la comprobación de la cone…

### DIFF
--- a/zoho-sync-core/zoho-sync-core.php
+++ b/zoho-sync-core/zoho-sync-core.php
@@ -259,6 +259,7 @@ final class ZohoSyncCore {
         } else {
             wp_send_json_error(array('message' => $result['message']));
         }
+        wp_die();
     }
 
     /**


### PR DESCRIPTION
…xión

He añadido `wp_die()` al final del `AJAX handler` de la comprobación de la conexión para prevenir que la respuesta JSON se corrompa con otros datos. Esto soluciona un error que provocaba que el script de administración no pudiera interpretar la respuesta del servidor.