### PR TITLE
Feat: Implementar el flujo de autorización de Zoho

### DIFF
--- a/zoho-sync-core/admin/assets/js/admin.js
+++ b/zoho-sync-core/admin/assets/js/admin.js
@@ -8,7 +8,7 @@
 
             var data = {
                 'action': 'zoho_sync_core_check_connection',
-                'nonce': zohoSyncCore.nonce
+                'nonce': zohoSyncCore.check_connection_nonce
             };
 
             $.post(zohoSyncCore.ajax_url, data, function(response) {
@@ -20,6 +20,25 @@
             }).fail(function(xhr, status, error) {
                 $status.text('An error occurred: ' + error);
                 console.error(xhr.responseText);
+            });
+        });
+
+        $('#zoho-generate-auth-url').on('click', function() {
+            var $urlContainer = $('#zoho-auth-url-container');
+            var $urlLink = $('#zoho-auth-url');
+
+            var data = {
+                'action': 'zoho_sync_core_generate_auth_url',
+                'nonce': zohoSyncCore.generate_auth_url_nonce
+            };
+
+            $.post(zohoSyncCore.ajax_url, data, function(response) {
+                if (response.success) {
+                    $urlLink.attr('href', response.data.url).text(response.data.url);
+                    $urlContainer.show();
+                } else {
+                    alert(response.data.message);
+                }
             });
         });
     });

--- a/zoho-sync-core/admin/partials/settings-display.php
+++ b/zoho-sync-core/admin/partials/settings-display.php
@@ -7,6 +7,10 @@
         submit_button(__('Save Settings', 'zoho-sync-core'));
         ?>
         <button type="button" id="zoho-check-connection" class="button button-secondary"><?php _e('Check Connection', 'zoho-sync-core'); ?></button>
+        <button type="button" id="zoho-generate-auth-url" class="button button-secondary"><?php _e('Generate Authorization URL', 'zoho-sync-core'); ?></button>
         <span id="zoho-connection-status"></span>
+        <p id="zoho-auth-url-container" style="display:none;">
+            <a href="#" id="zoho-auth-url" target="_blank"></a>
+        </p>
     </form>
 </div>


### PR DESCRIPTION
Se ha implementado el flujo de autorización de Zoho para que puedas obtener el 'Refresh Token' y el 'Access Token'. Se ha añadido un botón para generar la URL de autorización y se ha implementado la lógica para manejar el `callback` de Zoho.