### PR TITLE
Refactor: Mejorar el flujo de generación de la URL de autorización

### DIFF
--- a/zoho-sync-core/admin/assets/js/admin.js
+++ b/zoho-sync-core/admin/assets/js/admin.js
@@ -22,24 +22,5 @@
                 console.error(xhr.responseText);
             });
         });
-
-        $('#zoho-generate-auth-url').on('click', function() {
-            var $urlContainer = $('#zoho-auth-url-container');
-            var $urlLink = $('#zoho-auth-url');
-
-            var data = {
-                'action': 'zoho_sync_core_generate_auth_url',
-                'nonce': zohoSyncCore.generate_auth_url_nonce
-            };
-
-            $.post(zohoSyncCore.ajax_url, data, function(response) {
-                if (response.success) {
-                    $urlLink.attr('href', response.data.url).text(response.data.url);
-                    $urlContainer.show();
-                } else {
-                    alert(response.data.message);
-                }
-            });
-        });
     });
 })(jQuery);

--- a/zoho-sync-core/admin/partials/settings-display.php
+++ b/zoho-sync-core/admin/partials/settings-display.php
@@ -7,10 +7,27 @@
         submit_button(__('Save Settings', 'zoho-sync-core'));
         ?>
         <button type="button" id="zoho-check-connection" class="button button-secondary"><?php _e('Check Connection', 'zoho-sync-core'); ?></button>
-        <button type="button" id="zoho-generate-auth-url" class="button button-secondary"><?php _e('Generate Authorization URL', 'zoho-sync-core'); ?></button>
         <span id="zoho-connection-status"></span>
-        <p id="zoho-auth-url-container" style="display:none;">
-            <a href="#" id="zoho-auth-url" target="_blank"></a>
-        </p>
     </form>
+    <hr>
+    <h2><?php _e('Authorization', 'zoho-sync-core'); ?></h2>
+    <?php
+    $options = get_option('zoho_sync_core_settings');
+    $client_id = isset($options['zoho_client_id']) ? $options['zoho_client_id'] : '';
+    $client_secret = isset($options['zoho_client_secret']) ? $options['zoho_client_secret'] : '';
+
+    if (!empty($client_id) && !empty($client_secret)) {
+        $auth_manager = new Zoho_Sync_Core_Auth_Manager();
+        $redirect_uri = admin_url('admin.php?page=zoho-sync-core');
+        $auth_url = $auth_manager->get_authorization_url('inventory', 'com', $redirect_uri);
+        ?>
+        <p><?php _e('Click the link below to authorize the application with Zoho.', 'zoho-sync-core'); ?></p>
+        <p><a href="<?php echo esc_url($auth_url); ?>" target="_blank"><?php _e('Authorize with Zoho', 'zoho-sync-core'); ?></a></p>
+        <?php
+    } else {
+        ?>
+        <p><?php _e('Please save your Client ID and Client Secret to generate the authorization URL.', 'zoho-sync-core'); ?></p>
+        <?php
+    }
+    ?>
 </div>

--- a/zoho-sync-core/zoho-sync-core.php
+++ b/zoho-sync-core/zoho-sync-core.php
@@ -249,35 +249,7 @@ final class ZohoSyncCore {
             new Zoho_Sync_Core_Admin_Notices();
             add_action('admin_enqueue_scripts', array($this, 'enqueue_admin_scripts'));
             add_action('wp_ajax_zoho_sync_core_check_connection', array($this, 'check_connection_ajax'));
-            add_action('wp_ajax_zoho_sync_core_generate_auth_url', array($this, 'generate_auth_url_ajax'));
         }
-    }
-
-    /**
-     * AJAX handler for generating the authorization URL.
-     */
-    public function generate_auth_url_ajax() {
-        check_ajax_referer('zoho_sync_core_generate_auth_url', 'nonce');
-
-        $options = get_option('zoho_sync_core_settings');
-        $client_id = isset($options['zoho_client_id']) ? $options['zoho_client_id'] : '';
-        $client_secret = isset($options['zoho_client_secret']) ? $options['zoho_client_secret'] : '';
-
-        if (empty($client_id) || empty($client_secret)) {
-            wp_send_json_error(array('message' => 'Please save your Client ID and Client Secret first.'));
-            wp_die();
-        }
-
-        $auth_manager = new Zoho_Sync_Core_Auth_Manager();
-        $redirect_uri = admin_url('admin.php?page=zoho-sync-core');
-        $url = $auth_manager->get_authorization_url('inventory', 'com', $redirect_uri);
-
-        if ($url) {
-            wp_send_json_success(array('url' => $url));
-        } else {
-            wp_send_json_error(array('message' => 'Could not generate authorization URL.'));
-        }
-        wp_die();
     }
 
     /**
@@ -316,8 +288,7 @@ final class ZohoSyncCore {
         wp_enqueue_script('zoho-sync-core-admin', ZOHO_SYNC_CORE_ADMIN_URL . 'assets/js/admin.js', array('jquery'), ZOHO_SYNC_CORE_VERSION, true);
         wp_localize_script('zoho-sync-core-admin', 'zohoSyncCore', array(
             'ajax_url' => admin_url('admin-ajax.php'),
-            'check_connection_nonce'   => wp_create_nonce('zoho_sync_core_check_connection'),
-            'generate_auth_url_nonce' => wp_create_nonce('zoho_sync_core_generate_auth_url')
+            'check_connection_nonce'   => wp_create_nonce('zoho_sync_core_check_connection')
         ));
     }
     


### PR DESCRIPTION
He refactorizado la forma en que se genera la URL de autorización para que sea más robusta y menos propensa a errores. En lugar de usar AJAX, la URL se genera directamente en la página de configuración después de guardar las credenciales.