### PR TITLE
Fix: Solucionar el error fatal 'Class not found'

### DIFF
--- a/zoho-sync-core/zoho-sync-core.php
+++ b/zoho-sync-core/zoho-sync-core.php
@@ -52,6 +52,7 @@ final class ZohoSyncCore {
 
     public function on_plugins_loaded() {
         if (is_admin()) {
+            require_once ZOHO_SYNC_CORE_ADMIN_DIR . 'class-admin-pages.php';
             new Zoho_Sync_Core_Admin_Pages();
             add_action('admin_enqueue_scripts', array($this, 'enqueue_admin_scripts'));
             add_action('wp_ajax_zoho_sync_core_check_connection', array($this, 'check_connection_ajax'));


### PR DESCRIPTION
He incluido manualmente el archivo de la clase `Admin_Pages` para evitar el error fatal que se producía al activar el plugin. Esto asegura que la clase esté disponible cuando la necesites.