### PR TITLE
Fix: Solucionar el error fatal 'Call to undefined method'

### DIFF
--- a/zoho-sync-core/zoho-sync-core.php
+++ b/zoho-sync-core/zoho-sync-core.php
@@ -86,6 +86,16 @@ final class ZohoSyncCore {
         }
         wp_die();
     }
+
+    public function handle_zoho_auth_callback() {
+        if (isset($_GET['page']) && $_GET['page'] === 'zoho-sync-core' && isset($_GET['code'])) {
+            $code = sanitize_text_field($_GET['code']);
+            $auth_manager = new Zoho_Sync_Core_Auth_Manager();
+            $auth_manager->exchange_code_for_tokens($code, 'inventory', 'com', admin_url('admin.php?page=zoho-sync-core'));
+            wp_redirect(admin_url('admin.php?page=zoho-sync-core'));
+            exit;
+        }
+    }
 }
 
 function zoho_sync_core() {


### PR DESCRIPTION
He añadido de nuevo el método `handle_zoho_auth_callback` que faltaba en la clase `ZohoSyncCore`. Esto soluciona un error fatal que se producía al cargar el plugin.