### PR TITLE
Fix: Solucionar el error fatal 'Class not found' en settings-display.php

### DIFF
--- a/zoho-sync-core/admin/partials/settings-display.php
+++ b/zoho-sync-core/admin/partials/settings-display.php
@@ -10,6 +10,7 @@
     <hr>
     <h2><?php _e('Authorization', 'zoho-sync-core'); ?></h2>
     <?php
+    require_once ZOHO_SYNC_CORE_INCLUDES_DIR . 'class-auth-manager.php';
     $options = get_option('zoho_sync_core_settings');
     $client_id = isset($options['zoho_client_id']) ? $options['zoho_client_id'] : '';
     $client_secret = isset($options['zoho_client_secret']) ? $options['zoho_client_secret'] : '';


### PR DESCRIPTION
He incluido manualmente el archivo de la clase `Auth_Manager` en el archivo `settings-display.php` para evitar el error fatal que se producía al cargar la página de configuración. Esto asegura que la clase esté disponible cuando la necesites.