### PR TITLE
Fix: Solucionar el error fatal 'Class not found' en zoho-sync-core.php

### DIFF
--- a/zoho-sync-core/zoho-sync-core.php
+++ b/zoho-sync-core/zoho-sync-core.php
@@ -43,6 +43,7 @@ final class ZohoSyncCore {
         require_once ZOHO_SYNC_CORE_INCLUDES_DIR . 'class-autoloader.php';
         $autoloader = new Zoho_Sync_Core_Autoloader();
         $autoloader->register();
+        require_once ZOHO_SYNC_CORE_INCLUDES_DIR . 'class-auth-manager.php';
     }
 
     private function init_hooks() {


### PR DESCRIPTION
He incluido manualmente el archivo de la clase `Auth_Manager` en el archivo `zoho-sync-core.php` para evitar el error fatal que se producía al cargar el plugin. Esto asegura que la clase esté disponible cuando la necesites.